### PR TITLE
Update chain-data.ts - Ethereum

### DIFF
--- a/src/lib/chain-data.ts
+++ b/src/lib/chain-data.ts
@@ -86,8 +86,8 @@ export const chainData: Chain[] = [
       "https://w7.pngwing.com/pngs/715/916/png-transparent-ethereum%EF%BC%8Ceth%EF%BC%8Cicon.png",
     hardwareRequirements: {
       cpuCores: 4,
-      RAM: 16,
-      storage: 1000,
+      RAM: 32,
+      storage: 4000,
       refLink:
         "https://www.quicknode.com/guides/infrastructure/node-setup/ethereum-full-node-vs-archive-node#what-is-an-ethereum-full-node",
     },


### PR DESCRIPTION
for Ethereum, 16 GB is currently possible but 32 GB is recommended. 

1 TB is currently not possible (unless you're very skilled), 2 TB is possible but 4 TB is recommended. I think it makes sense to align these numbers with what's "officially" recommended rather than what's "minimum viable"

This'll bring Ethereum down the list but I think it's good to be as realistic as possible