### PR TITLE
fix: adjusted zksync specs

### DIFF
--- a/src/lib/chain-data.ts
+++ b/src/lib/chain-data.ts
@@ -149,8 +149,8 @@ export const chainData: Chain[] = [
     iconURL: "/zksync.webp",
     hardwareRequirements: {
       cpuCores: 4,
-      RAM: 16,
-      storage: 700,
+      RAM: 32,
+      storage: 500,
       bandwidth: 2,
       refLink:
         "https://github.com/matter-labs/zksync-era/blob/main/docs/src/guides/external-node/00_quick_start.md",


### PR DESCRIPTION
Adjusted the hardware requirements for the ZKSync Era, based on their docs: https://github.com/matter-labs/zksync-era/blob/main/docs/src/guides/external-node/00_quick_start.md#system-requirements